### PR TITLE
Add optional `aws_session_token` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Full list of options in `config.json`:
 |-------------------------------------|---------|------------|---------------------------------------------------------------|
 | aws_access_key_id                   | String  | Yes        | S3 Access Key Id                                              |
 | aws_secret_access_key               | String  | Yes        | S3 Secret Access Key                                          |
+| aws_session_token                   | String  | No         | (Optional.) S3 Token for use with temporary credentials.      |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can 
 | delimiter                           | String  |            | (Default: ',') A one-character string used to separate fields. |

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -27,10 +27,12 @@ def log_backoff_attempt(details):
 def setup_aws_client(config):
     aws_access_key_id = config['aws_access_key_id']
     aws_secret_access_key = config['aws_secret_access_key']
+    aws_session_token = config.get('aws_session_token', None)
 
     LOGGER.info("Attempting to create AWS session")
     boto3.setup_default_session(aws_access_key_id=aws_access_key_id,
-                                aws_secret_access_key=aws_secret_access_key)
+                                aws_secret_access_key=aws_secret_access_key,
+                                aws_session_token=aws_session_token)
 
 @retry_pattern()
 def upload_file(filename, bucket, key_prefix,


### PR DESCRIPTION
As I am currently in the process of dockerizing this target plugin to run directly from the ECS service, I'd love to merge this small update, which adds support for an optional `aws_session_token` as part of the config.

It is only a small number of use cases where a security token `AWS_SESSION_TOKEN` is needed in addition to the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Specifically, for my use case, this applies to scenarios when running in ECS and leveraging the AWS credentials of the host container.