### PR TITLE
[AP-662] Switch to Draft7Validator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(name="pipelinewise-target-s3-csv",
       ],
       py_modules=["target_s3_csv"],
       install_requires=[
-          'jsonschema==2.6.0',
           'pipelinewise-singer-python==1.*',
           'inflection==0.3.1',
           'boto3==1.9.57',

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -12,7 +12,7 @@ import tempfile
 from datetime import datetime
 
 import singer
-from jsonschema import Draft4Validator, FormatChecker
+from jsonschema import Draft7Validator, FormatChecker
 
 from target_s3_csv import s3
 from target_s3_csv import utils
@@ -109,7 +109,7 @@ def persist_messages(messages, config):
                 schemas[stream] = utils.add_metadata_columns_to_schema(o)
 
             schema = utils.float_to_decimal(o['schema'])
-            validators[stream] = Draft4Validator(schema, format_checker=FormatChecker())
+            validators[stream] = Draft7Validator(schema, format_checker=FormatChecker())
             key_properties[stream] = o['key_properties']
         elif message_type == 'ACTIVATE_VERSION':
             logger.debug('ACTIVATE_VERSION message')


### PR DESCRIPTION
The upstream pipelinewise-singer-python bumped jsonschema-2.6.0 to the more recent 3.2.0. As part of the upgrade we also want to replace the old Draft4Validator to Draft7Validator.

Related PR at transferwise/pipelinewise-singer-python#10