### PR TITLE
Issue - 14 data lake features

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Full list of options in `config.json`:
 | encryption_type                     | String  | No         | (Default: 'none') The type of encryption to use. Current supported options are: 'none' and 'KMS'. |
 | encryption_key                      | String  | No         | A reference to the encryption key to use for data encryption. For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234'). This field is ignored if 'encryption_type' is none or blank. |
 | compression                         | String  | No         | The type of compression to apply before uploading. Supported options are `none` (default) and `gzip`. For gzipped files, the file extension will automatically be changed to `.csv.gz` for all files. |
+| naming_convention                   | String  | No         | (Default: None) Custom naming convention of the s3 key. Replaces tokens `stream` and `timestamp` with the appropriate values. <br><br>Supports "folders" in s3 keys e.g. `folder/folder2/{stream}/{timestamp}.csv`. <br><br>Honors the `s3_key_prefix`,  if set, by prepending the "filename". E.g. naming_convention = `folder1/my_file.csv` and s3_key_prefix = `prefix_` results in `folder1/prefix_my_file.csv` |
 
 ### To run tests:
 

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -33,10 +33,10 @@ def setup_aws_client(config):
                                 aws_secret_access_key=aws_secret_access_key)
 
 @retry_pattern()
-def upload_file(filename, bucket, key_prefix,
+def upload_file(filename, bucket, s3_key,
                 encryption_type=None, encryption_key=None):
     s3_client = boto3.client('s3', config=Config(signature_version='s3v4'))
-    s3_key = "{}{}".format(key_prefix, os.path.basename(filename))
+    # s3_key = "{}{}".format(key_prefix, os.path.basename(filename))
 
     if encryption_type is None or encryption_type.lower() == "none":
         # No encryption config (defaults to settings on the bucket):

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -131,5 +131,6 @@ def get_target_key(message, prefix=None, timestamp=None, naming_convention=None)
         if k in key:
             key = key.replace(k, v)
     if prefix:
-        key = f'{prefix}{key}'
+        filename = key.split('/')[-1]
+        key = key.replace(filename, f'{prefix}{filename}')
     return key

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -115,3 +115,21 @@ def flatten_record(d, parent_key=[], sep='__'):
         else:
             items.append((new_key, json.dumps(v) if type(v) is list else v))
     return dict(items)
+
+
+def get_target_key(message, prefix=None, timestamp=None, naming_convention=None):
+    """Creates and returns an S3 key for the message"""
+    if not naming_convention:
+        naming_convention = '{stream}-{timestamp}.csv' # o['stream'] + '-' + now + '.csv'
+    if not timestamp:
+        timestamp = datetime.now().strftime('%Y%m%dT%H%M%S')
+    key = naming_convention
+    for k, v in {
+        '{stream}': message['stream'],
+        '{timestamp}': timestamp,
+    }.items():
+        if k in key:
+            key = key.replace(k, v)
+    if prefix:
+        key = f'{prefix}{key}'
+    return key

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -83,3 +83,11 @@ class TestIntegration(unittest.TestCase):
         # Invalid compression method should raise exception
         with assert_raises(NotImplementedError):
             self.persist_messages(tap_lines)
+
+    
+    def test_naming_convention(self):
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+
+        self.config['naming_convention'] = "tester/{stream}/{timestamp}.csv"
+        self.persist_messages(tap_lines)
+        self.assert_three_streams_are_in_s3_bucket()

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -3,7 +3,6 @@ from nose.tools import assert_raises
 
 import target_s3_csv
 
-
 class TestUnit(unittest.TestCase):
     """
     Unit Tests
@@ -31,4 +30,26 @@ class TestUnit(unittest.TestCase):
 
         # Minimal configuratino should pass - (nr_of_errors == 0)
         self.assertEqual(len(validator(minimal_config)), 0)
+
+
+    def test_naming_convention_replaces_tokens(self):
+        message = {
+            'stream': 'the_stream'
+        }
+        timestamp = 'fake_timestamp'
+        s3_key = target_s3_csv.utils.get_target_key(message, timestamp=timestamp, naming_convention='test_{stream}_{timestamp}_test.csv')
+
+        self.assertEqual('test_the_stream_fake_timestamp_test.csv', s3_key)
+
+
+    def test_naming_convention_has_reasonable_default(self):
+        message = {
+            'stream': 'the_stream'
+        }
+        s3_key = target_s3_csv.utils.get_target_key(message)
+
+        # default is "{stream}-{timestamp}.csv"
+        self.assertTrue(s3_key.startswith('the_stream'))
+        self.assertTrue(s3_key.endswith('.csv'))
+
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -33,6 +33,7 @@ class TestUnit(unittest.TestCase):
 
 
     def test_naming_convention_replaces_tokens(self):
+        """Test that the naming_convention tokens are replaced"""
         message = {
             'stream': 'the_stream'
         }
@@ -43,6 +44,7 @@ class TestUnit(unittest.TestCase):
 
 
     def test_naming_convention_has_reasonable_default(self):
+        """Test the default value of the naming convention"""
         message = {
             'stream': 'the_stream'
         }
@@ -53,3 +55,11 @@ class TestUnit(unittest.TestCase):
         self.assertTrue(s3_key.endswith('.csv'))
 
 
+    def test_naming_convention_honors_prefix(self):
+        """Test that if the prefix is set in the config, that it is used in the s3 key"""
+        message = {
+            'stream': 'the_stream'
+        }
+        s3_key = target_s3_csv.utils.get_target_key(message, prefix='the_prefix__', naming_convention='folder1/test_{stream}_test.csv')
+
+        self.assertEqual('folder1/the_prefix__test_the_stream_test.csv', s3_key)


### PR DESCRIPTION
#14 requested some data lake features. 
* I added more control over naming conventions, while ensuring backwards compatibility. 
* `naming_convention` is now a supported parameter
* `{stream}` in `naming_convention` is replaced by the stream name
* `{timestamp}` in `naming_convention` is replaced by the timestamp
* The original s3 key name of `stream-timestamp.csv` remains as the default naming convention, and is used if one is not provided
* The `s3_key_prefix` now prepends the *filename* part of the key, not as a prefix on the whole key. I did this because although not technically correct, it supports what I believe are the majority of use cases (actually, if naming_convention is specified, s3_key_prefix will rarely if ever be needed).
* Added some unit tests and an integration test.
* updated readme