### PR TITLE
[AP-822] Add profile based auth, session_token and creds from env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install .[test]
+            export LOGGING_CONF_FILE=$(pwd)/sample_logging.conf
             nosetests --where=tests/unit
 
       - run:
@@ -33,6 +34,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install .[test]
+            export LOGGING_CONF_FILE=$(pwd)/sample_logging.conf
             nosetests --where=tests/integration/
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -53,18 +53,27 @@ Running the the target connector requires a `config.json` file. An example with 
 
    ```json
    {
-     "aws_access_key_id": "secret",
-     "aws_secret_access_key": "secret",
      "s3_bucket": "my_bucket"
    }
    ```
+
+### Profile based authentication
+
+Profile based authentication used by default using the `default` profile. To use another profile set `aws_profile` parameter in `config.json` or set the `AWS_PROFILE` environment variable.
+
+### Non-Profile based authentication
+
+For non-profile based authentication set `aws_access_key_id` , `aws_secret_access_key` and optionally the `aws_session_token` parameter in the `config.json`. Alternatively you can define them out of `config.json` by setting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
+
 
 Full list of options in `config.json`:
 
 | Property                            | Type    | Required?  | Description                                                   |
 |-------------------------------------|---------|------------|---------------------------------------------------------------|
-| aws_access_key_id                   | String  | Yes        | S3 Access Key Id                                              |
-| aws_secret_access_key               | String  | Yes        | S3 Secret Access Key                                          |
+| aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, `AWS_ACCESS_KEY_ID` environment variable will be used. |
+| aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used. |
+| aws_session_token                   | String  | No         | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
+| aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can 
 | delimiter                           | String  |            | (Default: ',') A one-character string used to separate fields. |
@@ -120,4 +129,3 @@ Full list of options in `config.json`:
 Apache License Version 2.0
 
 See [LICENSE](LICENSE) to see the full text.
-

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -173,7 +173,7 @@ def main():
         logger.error("Invalid configuration:\n   * {}".format('\n   * '.join(config_errors)))
         sys.exit(1)
 
-    s3_client = s3.client_client(config)
+    s3_client = s3.create_client(config)
 
     input_messages = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     state = persist_messages(input_messages, config, s3_client)

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -3,7 +3,6 @@ import os
 import backoff
 import boto3
 import singer
-from botocore.client import Config
 from botocore.exceptions import ClientError
 
 LOGGER = singer.get_logger('target_s3_csv')
@@ -45,6 +44,7 @@ def create_client(config):
     return aws_session.client('s3')
 
 
+# pylint: disable=too-many-arguments
 @retry_pattern()
 def upload_file(filename, s3_client, bucket, s3_key,
                 encryption_type=None, encryption_key=None):

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-
 import os
-
 import backoff
 import boto3
 import singer
@@ -24,19 +22,32 @@ def log_backoff_attempt(details):
 
 
 @retry_pattern()
-def setup_aws_client(config):
-    aws_access_key_id = config['aws_access_key_id']
-    aws_secret_access_key = config['aws_secret_access_key']
-
+def create_client(config):
     LOGGER.info("Attempting to create AWS session")
-    boto3.setup_default_session(aws_access_key_id=aws_access_key_id,
-                                aws_secret_access_key=aws_secret_access_key)
+
+    # Get the required parameters from config file and/or environment variables
+    aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
+    aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
+    aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+    aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
+
+    # AWS credentials based authentication
+    if aws_access_key_id and aws_secret_access_key:
+        aws_session = boto3.session.Session(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token
+        )
+    # AWS Profile based authentication
+    else:
+        aws_session = boto3.session.Session(profile_name=aws_profile)
+
+    return aws_session.client('s3')
+
 
 @retry_pattern()
-def upload_file(filename, bucket, s3_key,
+def upload_file(filename, s3_client, bucket, s3_key,
                 encryption_type=None, encryption_key=None):
-    s3_client = boto3.client('s3', config=Config(signature_version='s3v4'))
-    # s3_key = "{}{}".format(key_prefix, os.path.basename(filename))
 
     if encryption_type is None or encryption_type.lower() == "none":
         # No encryption config (defaults to settings on the bucket):

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -13,12 +13,11 @@ from datetime import datetime
 
 logger = singer.get_logger('target_s3_csv')
 
+
 def validate_config(config):
     """Validates config"""
     errors = []
     required_config_keys = [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         's3_bucket'
     ]
 
@@ -59,6 +58,7 @@ def add_metadata_columns_to_schema(schema_message):
 
     return extended_schema_message
 
+
 def add_metadata_values_to_record(record_message, schema_message):
     """Populate metadata _sdc columns from incoming record message
     The location of the required attributes are fixed in the stream
@@ -73,6 +73,7 @@ def add_metadata_values_to_record(record_message, schema_message):
     extended_record['_sdc_table_version'] = record_message.get('version')
 
     return extended_record
+
 
 def remove_metadata_values_from_record(record_message):
     """Removes every metadata _sdc column from a given record message

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -84,7 +84,7 @@ class TestIntegration(unittest.TestCase):
             s3_client_aws_env_vars = s3.create_client(config_aws_env_vars)
             self.persist_messages(tap_lines, s3_client_aws_env_vars)
             self.assert_three_streams_are_in_s3_bucket()
-        # Delete temporary env var to not confuxe other tests
+        # Delete temporary env var to not confuse other tests
         finally:
             del os.environ['AWS_ACCESS_KEY_ID']
             del os.environ['AWS_SECRET_ACCESS_KEY']
@@ -106,7 +106,7 @@ class TestIntegration(unittest.TestCase):
             config_aws_profile_env_vars = {}
             with self.assertRaises(botocore.exceptions.ProfileNotFound):
                 s3.create_client(config_aws_profile_env_vars)
-        # Delete temporary env var to not confuxe other tests
+        # Delete temporary env var to not confuse other tests
         finally:
             del os.environ['AWS_PROFILE']
 

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -1,6 +1,7 @@
-import json
+import os
 import unittest
 import simplejson
+import botocore
 
 from nose.tools import assert_raises
 
@@ -22,7 +23,7 @@ class TestIntegration(unittest.TestCase):
 
     def setUp(self):
         self.config = test_utils.get_test_config()
-        s3.setup_aws_client(self.config)
+        self.s3_client = s3.create_client(self.config)
 
     def assert_three_streams_are_in_s3_bucket(self,
                                               should_metadata_columns_exist=False,
@@ -41,9 +42,11 @@ class TestIntegration(unittest.TestCase):
         #       parameters
         self.assertTrue(True)
 
-    def persist_messages(self, messages):
+    def persist_messages(self, messages, s3_client=None):
         """Load data into S3"""
-        target_s3_csv.persist_messages(messages, self.config)
+        if s3_client is None:
+            s3_client = self.s3_client
+        target_s3_csv.persist_messages(messages, self.config, s3_client)
 
     def test_invalid_json(self):
         """Receiving invalid JSONs should raise an exception"""
@@ -63,6 +66,49 @@ class TestIntegration(unittest.TestCase):
 
         self.persist_messages(tap_lines)
         self.assert_three_streams_are_in_s3_bucket()
+
+    def test_aws_env_vars(self):
+        """Test loading data with credentials defined in AWS environment variables
+        rather than explicitly provided access keys"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        try:
+            # Move aws access key and secret from config into environment variables
+            os.environ['AWS_ACCESS_KEY_ID'] = os.environ.get('TARGET_S3_CSV_ACCESS_KEY_ID')
+            os.environ['AWS_SECRET_ACCESS_KEY'] = os.environ.get('TARGET_S3_CSV_SECRET_ACCESS_KEY')
+
+            config_aws_env_vars = self.config.copy()
+            config_aws_env_vars['aws_access_key_id'] = None
+            config_aws_env_vars['aws_secret_access_key'] = None
+
+            # Create a new S3 client using env vars
+            s3_client_aws_env_vars = s3.create_client(config_aws_env_vars)
+            self.persist_messages(tap_lines, s3_client_aws_env_vars)
+            self.assert_three_streams_are_in_s3_bucket()
+        # Delete temporary env var to not confuxe other tests
+        finally:
+            del os.environ['AWS_ACCESS_KEY_ID']
+            del os.environ['AWS_SECRET_ACCESS_KEY']
+
+    def test_profile_based_auth(self):
+        """Test AWS profile based authentication rather than access keys"""
+        # Profile name given in config
+        config_aws_profile = {
+            'aws_profile': 'fake_profile'
+        }
+        with self.assertRaises(botocore.exceptions.ProfileNotFound):
+            s3.create_client(config_aws_profile)
+
+    def test_profile_based_auth_aws_env_var(self):
+        """Test AWS profile based authentication using AWS environment variables"""
+        try:
+            # Profile name defined as env var and config is empty
+            os.environ['AWS_PROFILE'] = 'fake_profile'
+            config_aws_profile_env_vars = {}
+            with self.assertRaises(botocore.exceptions.ProfileNotFound):
+                s3.create_client(config_aws_profile_env_vars)
+        # Delete temporary env var to not confuxe other tests
+        finally:
+            del os.environ['AWS_PROFILE']
 
     def test_loading_csv_files_with_gzip_compression(self):
         """Loading multiple tables from the same input tap with gzip compression"""
@@ -84,7 +130,6 @@ class TestIntegration(unittest.TestCase):
         with assert_raises(NotImplementedError):
             self.persist_messages(tap_lines)
 
-    
     def test_naming_convention(self):
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
 


### PR DESCRIPTION
The tap is currently using hard coded `aws_access_key_id` and `aws_secret_access_key` to connect to S3.

This is OK., but not great. Instead of hard coded credentials we should be able to use env vars, AWS profile based authentication and IAM roles as alternative authentication methods when connecting to S3.


This PR adds these features to this target.

* config.json: `aws_profile` -  Env var: `AWS_PROFILE`
* config.json: `aws_access_key_id` - Env var: `AWS_ACCESS_KEY_ID`
* config.json: `aws_secret_access_key` - Env var: `AWS_SECRET_ACCESS_KEY`
* config.json: `aws_session_token` - Env var: `AWS_SESSION_TOKEN`


The tap is using profile based authentication by default using the `default` profile. The PR is fully backward compatible.