### PR TITLE
Publish README.md to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,14 @@
 
 from setuptools import setup
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(name="pipelinewise-target-s3-csv",
       version="1.3.0",
       description="Singer.io target for writing CSV files and upload to S3 - PipelineWise compatible",
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author="TransferWise",
       url='https://github.com/transferwise/pipelinewise-target-s3-csv',
       classifiers=[


### PR DESCRIPTION
This PR making `README.md` available on PyPI similar to other PPW connectors.

Currently https://pypi.org/project/pipelinewise-target-s3-csv/ shows a blank page.