### PR TITLE
[AP-846] Add temp_dir optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Full list of options in `config.json`:
 | encryption_key                      | String  | No         | A reference to the encryption key to use for data encryption. For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234'). This field is ignored if 'encryption_type' is none or blank. |
 | compression                         | String  | No         | The type of compression to apply before uploading. Supported options are `none` (default) and `gzip`. For gzipped files, the file extension will automatically be changed to `.csv.gz` for all files. |
 | naming_convention                   | String  | No         | (Default: None) Custom naming convention of the s3 key. Replaces tokens `date`, `stream`, and `timestamp` with the appropriate values. <br><br>Supports "folders" in s3 keys e.g. `folder/folder2/{stream}/export_date={date}/{timestamp}.csv`. <br><br>Honors the `s3_key_prefix`,  if set, by prepending the "filename". E.g. naming_convention = `folder1/my_file.csv` and s3_key_prefix = `prefix_` results in `folder1/prefix_my_file.csv` |
+| temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 
 ### To run tests:
 

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -38,7 +38,11 @@ def persist_messages(messages, config, s3_client):
 
     delimiter = config.get('delimiter', ',')
     quotechar = config.get('quotechar', '"')
-    temp_dir = config.get('temp_dir', tempfile.gettempdir());
+    temp_dir = os.path.expanduser(config.get('temp_dir', tempfile.gettempdir()))
+
+    # Create custom temp_dir if not exists
+    if temp_dir:
+        os.makedirs(temp_dir, exist_ok=True)
 
     filenames = []
     now = datetime.now().strftime('%Y%m%dT%H%M%S')

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -38,9 +38,11 @@ def persist_messages(messages, config, s3_client):
 
     delimiter = config.get('delimiter', ',')
     quotechar = config.get('quotechar', '"')
+
+    # Use the system specific temp directory if no custom temp_dir provided
     temp_dir = os.path.expanduser(config.get('temp_dir', tempfile.gettempdir()))
 
-    # Create custom temp_dir if not exists
+    # Create temp_dir if not exists
     if temp_dir:
         os.makedirs(temp_dir, exist_ok=True)
 

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -38,6 +38,7 @@ def persist_messages(messages, config, s3_client):
 
     delimiter = config.get('delimiter', ',')
     quotechar = config.get('quotechar', '"')
+    temp_dir = config.get('temp_dir', tempfile.gettempdir());
 
     filenames = []
     now = datetime.now().strftime('%Y%m%dT%H%M%S')
@@ -72,7 +73,7 @@ def persist_messages(messages, config, s3_client):
                 record_to_load = utils.remove_metadata_values_from_record(o)
 
             filename = o['stream'] + '-' + now + '.csv'
-            filename = os.path.expanduser(os.path.join(tempfile.gettempdir(), filename))
+            filename = os.path.expanduser(os.path.join(temp_dir, filename))
             target_key = utils.get_target_key(o,
                                               prefix=config.get('s3_key_prefix', ''),
                                               timestamp=now,

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -136,3 +136,13 @@ class TestIntegration(unittest.TestCase):
         self.config['naming_convention'] = "tester/{stream}/{timestamp}.csv"
         self.persist_messages(tap_lines)
         self.assert_three_streams_are_in_s3_bucket()
+
+    def test_loading_tables_with_custom_temp_dir(self):
+        """Loading multiple tables from the same input tap using custom temp directory"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+
+        # Turning on client-side encryption and load
+        self.config['temp_dir'] = ('~/.pipelinewise/tmp/abc')
+        self.persist_messages(tap_lines)
+
+        self.assert_three_streams_are_in_s3_bucket()

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -142,7 +142,7 @@ class TestIntegration(unittest.TestCase):
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
 
         # Turning on client-side encryption and load
-        self.config['temp_dir'] = ('~/.pipelinewise/tmp/abc')
+        self.config['temp_dir'] = ('~/.pipelinewise/tmp')
         self.persist_messages(tap_lines)
 
         self.assert_three_streams_are_in_s3_bucket()

--- a/tests/integration/test_target_s3_csv.py
+++ b/tests/integration/test_target_s3_csv.py
@@ -141,7 +141,7 @@ class TestIntegration(unittest.TestCase):
         """Loading multiple tables from the same input tap using custom temp directory"""
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
 
-        # Turning on client-side encryption and load
+        # Use custom temp_dir
         self.config['temp_dir'] = ('~/.pipelinewise/tmp')
         self.persist_messages(tap_lines)
 


### PR DESCRIPTION
## Context

This PR adds the optional `temp_dir` parameter. This is useful if we don't want to create temporary files on system `/tmp` (on linux) directory but somewhere else.

### Changes

Changes are fully backward compatible, if no `temp_dir` provided then it behaves as earlier and will use the default system temp directory. 
