### PR TITLE
Support optional aws_endpoint_url configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Full list of options in `config.json`:
 | aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, `AWS_ACCESS_KEY_ID` environment variable will be used. |
 | aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used. |
 | aws_session_token                   | String  | No         | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
+| aws_endpoint_url                    | String  | No         | AWS endpoint URL. If not provided, `AWS_ENDPOINT_URL` environment variable will be used. |
 | aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Full list of options in `config.json`:
 | aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, `AWS_ACCESS_KEY_ID` environment variable will be used. |
 | aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable will be used. |
 | aws_session_token                   | String  | No         | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
-| aws_endpoint_url                    | String  | No         | AWS endpoint URL. If not provided, `AWS_ENDPOINT_URL` environment variable will be used. |
+| aws_endpoint_url                    | String  | No         | AWS endpoint URL. |
 | aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can 

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -29,6 +29,7 @@ def create_client(config):
     aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
     aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
     aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
+    aws_endpoint_url = config.get('aws_endpoint_url') or os.environ.get('AWS_ENDPOINT_URL')
 
     # AWS credentials based authentication
     if aws_access_key_id and aws_secret_access_key:
@@ -40,8 +41,11 @@ def create_client(config):
     # AWS Profile based authentication
     else:
         aws_session = boto3.session.Session(profile_name=aws_profile)
-
-    return aws_session.client('s3')
+    if aws_endpoint_url:
+        s3 = aws_session.client('s3', aws_endpoint_url=aws_endpoint_url)
+    else:
+        s3 = aws_session.client('s3')
+    return s3
 
 
 # pylint: disable=too-many-arguments

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -29,7 +29,7 @@ def create_client(config):
     aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
     aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
     aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
-    aws_endpoint_url = config.get('aws_endpoint_url') or os.environ.get('AWS_ENDPOINT_URL')
+    aws_endpoint_url = config.get('aws_endpoint_url')
 
     # AWS credentials based authentication
     if aws_access_key_id and aws_secret_access_key:

--- a/target_s3_csv/s3.py
+++ b/target_s3_csv/s3.py
@@ -42,7 +42,7 @@ def create_client(config):
     else:
         aws_session = boto3.session.Session(profile_name=aws_profile)
     if aws_endpoint_url:
-        s3 = aws_session.client('s3', aws_endpoint_url=aws_endpoint_url)
+        s3 = aws_session.client('s3', endpoint_url=aws_endpoint_url)
     else:
         s3 = aws_session.client('s3')
     return s3

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -67,7 +67,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual('folder1/the_prefix__test_the_stream_test.csv', s3_key)
 
 
-    @mock.patch("target_s3_csv.s3.boto3.session.Session.client")
+    @patch("target_s3_csv.s3.boto3.session.Session.client")
     def test_create_client(self, mock_client):
         """Test that if an endpoint_url is provided in the config, that it is used in client request"""
         config = {

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+
 from nose.tools import assert_raises
 
 import target_s3_csv
@@ -63,3 +65,15 @@ class TestUnit(unittest.TestCase):
         s3_key = target_s3_csv.utils.get_target_key(message, prefix='the_prefix__', naming_convention='folder1/test_{stream}_test.csv')
 
         self.assertEqual('folder1/the_prefix__test_the_stream_test.csv', s3_key)
+
+
+    @mock.patch("target_s3_csv.s3.boto3.session.Session.client")
+    def test_create_client(self, mock_client):
+        """Test that if an endpoint_url is provided in the config, that it is used in client request"""
+        config = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+            'aws_endpoint_url': 'other_url'
+        }
+        target_s3_csv.s3.create_client(config)
+        mock_client.assert_called_with('s3', endpoint_url='other_url')


### PR DESCRIPTION
## Problem

The tap doesn't currently support a custom endpoint_url for the S3 boto client.

## Proposed changes

Add support for accepting the aws_endpoint_url as an environment variable or config entry.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions