### PR TITLE
AP-1226 target resets state with every record

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pylint:
 
 unit_test:
 	. ./venv/bin/activate ;\
-	pytest tests/unit --cov target_s3_csv --cov-fail-under=76
+	pytest tests/unit --cov target_s3_csv --cov-fail-under=75
 
 integration_test:
 	. ./venv/bin/activate ;\

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ venv:
 
 pylint:
 	. ./venv/bin/activate ;\
-	pylint target_s3_csv -d C,W,unexpected-keyword-arg,duplicate-code
+	pylint target_s3_csv -d C,W
 
 unit_test:
 	. ./venv/bin/activate ;\
-	pytest tests/unit --cov target_s3_csv --cov-fail-under=31
+	pytest tests/unit --cov target_s3_csv --cov-fail-under=76
 
 integration_test:
 	. ./venv/bin/activate ;\
-	pytest tests/integration --cov target_s3_csv --cov-fail-under=71
+	pytest tests/integration --cov target_s3_csv --cov-fail-under=72

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ unit_test:
 
 integration_test:
 	. ./venv/bin/activate ;\
-	pytest tests/integration --cov target_s3_csv --cov-fail-under=72
+	pytest tests/integration --cov target_s3_csv --cov-fail-under=71

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -112,7 +112,6 @@ def persist_messages(messages, config, s3_client):
 
                 writer.writerow(flattened_record)
 
-            state = None
         elif message_type == 'STATE':
             logger.debug('Setting state to {}'.format(o['value']))
             state = o['value']

--- a/target_s3_csv/__init__.py
+++ b/target_s3_csv/__init__.py
@@ -131,34 +131,8 @@ def persist_messages(messages, config, s3_client):
                             .format(o['type'], o))
 
     # Upload created CSV files to S3
-    for filename, target_key in filenames:
-        compressed_file = None
-        if config.get("compression") is None or config["compression"].lower() == "none":
-            pass  # no compression
-        else:
-            if config["compression"] == "gzip":
-                compressed_file = f"{filename}.gz"
-                with open(filename, 'rb') as f_in:
-                    with gzip.open(compressed_file, 'wb') as f_out:
-                        logger.info(f"Compressing file as '{compressed_file}'")
-                        shutil.copyfileobj(f_in, f_out)
-            else:
-                raise NotImplementedError(
-                    "Compression type '{}' is not supported. "
-                    "Expected: 'none' or 'gzip'"
-                    .format(config["compression"])
-                )
-        s3.upload_file(compressed_file or filename,
-                       s3_client,
-                       config.get('s3_bucket'),
-                       target_key,
-                       encryption_type=config.get('encryption_type'),
-                       encryption_key=config.get('encryption_key'))
-
-        # Remove the local file(s)
-        os.remove(filename)
-        if compressed_file:
-            os.remove(compressed_file)
+    s3.upload_files(filenames, s3_client, config['s3_bucket'], config.get("compression"),
+                    config.get('encryption_type'), config.get('encryption_key'))
 
     return state
 

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-
-from datetime import datetime
 import time
 import singer
 import json
 import re
-import collections
 import inflection
 
 from decimal import Decimal
 from datetime import datetime
+from collections.abc import MutableMapping
 
 logger = singer.get_logger('target_s3_csv')
 
@@ -112,7 +110,7 @@ def flatten_record(d, parent_key=[], sep='__'):
     for k in sorted(d.keys()):
         v = d[k]
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, MutableMapping):
             items.extend(flatten_record(v, parent_key + [k], sep=sep).items())
         else:
             items.append((new_key, json.dumps(v) if type(v) is list else v))

--- a/target_s3_csv/utils.py
+++ b/target_s3_csv/utils.py
@@ -103,9 +103,14 @@ def flatten_key(k, parent_key, sep):
 
     return sep.join(inflected_key)
 
-def flatten_record(d, parent_key=[], sep='__'):
+
+def flatten_record(d, parent_key=None, sep='__'):
     """
     """
+
+    if parent_key is None:
+        parent_key = []
+
     items = []
     for k in sorted(d.keys()):
         v = d[k]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,62 @@
+import contextlib
+import io
+import json
+import unittest
+
+from unittest.mock import patch, Mock
+
+import pytest
+from botocore.client import BaseClient
+
+from target_s3_csv import emit_state, persist_messages
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.config = {
+            's3_bucket': 'my-awesome-bucket',
+        }
+
+    def test_emit_state_with_None_does_nothing(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            emit_state(None)
+            self.assertEqual('', f.getvalue())
+
+    def test_emit_state_with_dictionary_makes_dump(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            emit_state({'a': 1, 'b': 2, 'c': 'lool'})
+            self.assertEqual('{"a": 1, "b": 2, "c": "lool"}\n', f.getvalue())
+
+    @patch('target_s3_csv.open')
+    @patch('target_s3_csv.csv')
+    @patch('target_s3_csv.s3')
+    @patch('target_s3_csv.os')
+    def test_persist_messages(self, os, s3, csv, open):
+        messages = [
+            json.dumps({"type": "SCHEMA", "stream": "my_stream",
+                        "schema": {
+                            "properties": {
+                                "id": {"type": "integer"},
+                                "name": {"type": ["string", "null"]},
+                                "age": {"type": ["integer", "null"]},
+                            },
+                        },
+                        "key_properties": ["id"],
+                        "metadata": {}
+            }),
+            json.dumps({"type": "STATE", "stream": "my_stream", "value": {"bookmarks": {"my_stream": 1}}}),
+            json.dumps({"type": "RECORD", "stream": "my_stream", "record": {"id": 1, "name": "Steve", "age": 10}}),
+            json.dumps({"type": "RECORD", "stream": "my_stream", "record": {"id": 2, "name": "Peter", "age": 33}}),
+            json.dumps({"type": "RECORD", "stream": "my_stream", "record": {"id": 3, "name": "Pete", "age": 25}}),
+            json.dumps({"type": "RECORD", "stream": "my_stream", "record": {"id": 4, "name": "John", "age": 40}}),
+        ]
+
+        s3_client = Mock(spec_set=BaseClient)
+
+        state = persist_messages(messages, self.config, s3_client)
+
+        self.assertDictEqual({"bookmarks": {"my_stream": 1}}, state)
+        s3.upload_files.assert_called_once()

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,0 +1,136 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, Mock, call
+
+from botocore.client import BaseClient
+
+from target_s3_csv import s3
+
+
+class TestS3(unittest.TestCase):
+
+    @patch("target_s3_csv.s3.boto3.session.Session.client")
+    def test_create_client(self, mock_client):
+        """Test that if an endpoint_url is provided in the config, that it is used in client request"""
+        config = {
+            'aws_access_key_id': 'foo',
+            'aws_secret_access_key': 'bar',
+            'aws_endpoint_url': 'other_url'
+        }
+        s3.create_client(config)
+        mock_client.assert_called_with('s3', endpoint_url='other_url')
+
+    def test_upload_files_with_no_compression_nor_encryption(self):
+        file1 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file2 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file3 = tempfile.NamedTemporaryFile(suffix='.csv')
+
+        filenames = [
+            (file1.name, 'folder1/file.csv'),
+            (file2.name, 'folder2/file.csv'),
+            (file3.name, 'folder3/file.csv'),
+        ]
+
+        s3_client = Mock(**{
+            'upload_file.return_value': None
+        })
+
+        s3.upload_files(
+            filenames,
+            s3_client,
+            'my_bucket',
+            None,
+            None,
+            None
+        )
+
+        # make sure the uploading to s3 has been called once for each file
+        s3_client.upload_file.assert_has_calls(
+            [
+                call(file1.name, 'my_bucket', 'folder1/file.csv', ExtraArgs=None),
+                call(file2.name, 'my_bucket', 'folder2/file.csv', ExtraArgs=None),
+                call(file3.name, 'my_bucket', 'folder3/file.csv', ExtraArgs=None),
+            ]
+        )
+
+        # make sure that the upload_files function removed the files
+        self.assertFalse(os.path.exists(file1.name))
+        self.assertFalse(os.path.exists(file2.name))
+        self.assertFalse(os.path.exists(file3.name))
+
+    def test_upload_files_with_compression_and_no_encryption(self):
+        file1 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file2 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file3 = tempfile.NamedTemporaryFile(suffix='.csv')
+
+        filenames = [
+            (file1.name, 'folder1/file.csv'),
+            (file2.name, 'folder2/file.csv'),
+            (file3.name, 'folder3/file.csv'),
+        ]
+
+        s3_client = Mock(**{
+            'upload_file.return_value': None
+        })
+
+        s3.upload_files(
+            filenames,
+            s3_client,
+            'my_bucket',
+            'gzip',
+            None,
+            None
+        )
+
+        # make sure the uploading to s3 has been called once for each file
+        s3_client.upload_file.assert_has_calls(
+            [
+                call(f'{file1.name}.gz', 'my_bucket', 'folder1/file.csv.gz', ExtraArgs=None),
+                call(f'{file2.name}.gz', 'my_bucket', 'folder2/file.csv.gz', ExtraArgs=None),
+                call(f'{file3.name}.gz', 'my_bucket', 'folder3/file.csv.gz', ExtraArgs=None),
+            ]
+        )
+
+        # make sure that the upload_files function removed the files
+        self.assertFalse(os.path.exists(file1.name))
+        self.assertFalse(os.path.exists(file2.name))
+        self.assertFalse(os.path.exists(file3.name))
+
+    def test_upload_files_with_no_compression_and_with_encryption(self):
+        file1 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file2 = tempfile.NamedTemporaryFile(suffix='.csv')
+        file3 = tempfile.NamedTemporaryFile(suffix='.csv')
+
+        filenames = [
+            (file1.name, 'folder1/file.csv'),
+            (file2.name, 'folder2/file.csv'),
+            (file3.name, 'folder3/file.csv'),
+        ]
+
+        s3_client = Mock(**{
+            'upload_file.return_value': None
+        })
+
+        s3.upload_files(
+            filenames,
+            s3_client,
+            'my_bucket',
+            None,
+            'kms',
+            None
+        )
+
+        # make sure the uploading to s3 has been called once for each file
+        s3_client.upload_file.assert_has_calls(
+            [
+                call(f'{file1.name}', 'my_bucket', 'folder1/file.csv', ExtraArgs={'ServerSideEncryption': 'aws:kms'}),
+                call(f'{file2.name}', 'my_bucket', 'folder2/file.csv', ExtraArgs={'ServerSideEncryption': 'aws:kms'}),
+                call(f'{file3.name}', 'my_bucket', 'folder3/file.csv', ExtraArgs={'ServerSideEncryption': 'aws:kms'}),
+            ]
+        )
+
+        # make sure that the upload_files function removed the files
+        self.assertFalse(os.path.exists(file1.name))
+        self.assertFalse(os.path.exists(file2.name))
+        self.assertFalse(os.path.exists(file3.name))


### PR DESCRIPTION
## Problem

After receiving a `record` stream message, the target nullifies the state variable making it impossible for to update the state file unless that last stream message is of type state, and in case of failure the tap always restarts from very old state.  

## Proposed changes
Do no nullify the state when processing records.

### Misc
Added more unit tests and done some refactoring.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions