### PR TITLE
Drop Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_and_test:
     name: Linting and Testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,5 +37,5 @@ jobs:
             TARGET_S3_CSV_ACCESS_KEY_ID: ${{ secrets.TARGET_S3_CSV_ACCESS_KEY_ID }}
             TARGET_S3_CSV_SECRET_ACCESS_KEY: ${{ secrets.TARGET_S3_CSV_SECRET_ACCESS_KEY }}
             TARGET_S3_CSV_BUCKET: ${{ secrets.TARGET_S3_CSV_BUCKET }}
-            TARGET_S3_CSV_KEY_PREFIX: target_s3_csv/
+            TARGET_S3_CSV_KEY_PREFIX: target_s3_csv/ci_integration_py${{ matrix.python-version }}/
         run: make integration_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,11 +8,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you want to run this [Singer Target](https://singer.io) independently please 
 
 ## Install
 
-First, make sure Python 3 is installed on your system or follow these
+First, make sure Python >=3.7 is installed on your system or follow these
 installation instructions for [Mac](http://docs.python-guide.org/en/latest/starting/install3/osx/) or
 [Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-python-3-and-set-up-a-local-programming-environment-on-ubuntu-16-04).
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ with open('README.md') as f:
 
 setup(name="pipelinewise-target-s3-csv",
       version="1.5.0",
+      python_requires=">=3.7.0, <3.11",
       description="Singer.io target for writing CSV files and upload to S3 - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -34,6 +35,6 @@ setup(name="pipelinewise-target-s3-csv",
           target-s3-csv=target_s3_csv:main
        """,
       packages=["target_s3_csv"],
-      package_data = {},
+      package_data={},
       include_package_data=True,
-)
+      )


### PR DESCRIPTION
## Problem

Python 3.6 has reached EOF, some libraries cannot be bumped because python 3.6 CI path is breaking.

## Proposed changes

Drop Python 3.6

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions